### PR TITLE
Fix current dungeon tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.1
+
+- [BUGFIX] Fixes the Current Dungeon tab to display properly by properly handling endedAt being nil
+
 ## v0.3.0
 
 - Add amount of time the run took as well as when the run ended to the UI for each dungeon

--- a/Core.lua
+++ b/Core.lua
@@ -15,7 +15,7 @@ MplusLedger = LibStub("AceAddon-3.0"):NewAddon(
 )
 
 MplusLedger.Title = "MplusLedger"
-MplusLedger.Version = "0.3.0"
+MplusLedger.Version = "0.3.1"
 MplusLedger.ShowingMainFrame = false
 
 MplusLedger.Events = {

--- a/Frame.lua
+++ b/Frame.lua
@@ -106,48 +106,50 @@ local function AddDungeonLabelsToContainer(container, dungeon)
 
   container:AddChild(affixesLabel)
 
-  local endDateLabel = AceGUI:Create("Label")
-  endDateLabel:SetText("Ended on " .. date("%c", dungeon.endedAt))
-  endDateLabel:SetFont(font, fontSize * 1.1, flags) 
-  endDateLabel:SetRelativeWidth(0.8)
+  if dungeon.state ~= "running" then
+    local endDateLabel = AceGUI:Create("Label")
+    endDateLabel:SetText("Ended on " .. date("%c", dungeon.endedAt))
+    endDateLabel:SetFont(font, fontSize * 1.1, flags) 
+    endDateLabel:SetRelativeWidth(0.8)
 
-  container:AddChild(endDateLabel)
+    container:AddChild(endDateLabel)
 
-  local keyMod
-  local totalRuntime = difftime(dungeon.endedAt, dungeon.startedAt)
+    local keyMod
+    local totalRuntime = difftime(dungeon.endedAt, dungeon.startedAt)
 
-  if dungeon.state == "failed" then
-    keyMod = "-1"
-  else
-    local plusTwo = timeLimit * 0.8
-    local plusThree = timeLimit * 0.6
-    
-    if totalRuntime <= plusThree then
-      keyMod = "+3"
-    elseif totalRuntime <= plusTwo then
-      keyMod = "+2"
-    elseif totalRuntime <= timeLimit then
-      keyMod = "+1"
-    else
+    if dungeon.state == "failed" then
       keyMod = "-1"
+    else
+      local plusTwo = timeLimit * 0.8
+      local plusThree = timeLimit * 0.6
+      
+      if totalRuntime <= plusThree then
+        keyMod = "+3"
+      elseif totalRuntime <= plusTwo then
+        keyMod = "+2"
+      elseif totalRuntime <= timeLimit then
+        keyMod = "+1"
+      else
+        keyMod = "-1"
+      end
     end
-  end
 
-  local keyModLabel = AceGUI:Create("Label")
-  keyModLabel:SetText(keyMod)
-  keyModLabel:SetRelativeWidth(0.2)
-  keyModLabel:SetFont(font, fontSize * 1.5, flags)
-  keyModLabel:SetJustifyH("CENTER")
+    local keyModLabel = AceGUI:Create("Label")
+    keyModLabel:SetText(keyMod)
+    keyModLabel:SetRelativeWidth(0.2)
+    keyModLabel:SetFont(font, fontSize * 1.5, flags)
+    keyModLabel:SetJustifyH("CENTER")
 
-  container:AddChild(keyModLabel)
+    container:AddChild(keyModLabel)
+
+    local totalRunTimeLabel = AceGUI:Create("Label") 
+    totalRunTimeLabel:SetText("Total run time: " .. SecondsToClock(totalRuntime))
+    totalRunTimeLabel:SetFont(font, fontSize * 1.1, flags)
+    totalRunTimeLabel:SetRelativeWidth(0.8)
   
-  local totalRunTimeLabel = AceGUI:Create("Label") 
-  totalRunTimeLabel:SetText("Total run time: " .. SecondsToClock(totalRuntime))
-  totalRunTimeLabel:SetFont(font, fontSize * 1.1, flags)
-  totalRunTimeLabel:SetRelativeWidth(0.8)
-
-  container:AddChild(totalRunTimeLabel)
-
+    container:AddChild(totalRunTimeLabel)
+  end
+  
   local spacerLabel = AceGUI:Create("Label")
   spacerLabel:SetText("")
   spacerLabel:SetRelativeWidth(1.0)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MplusLedger
 
 <img src="https://img.shields.io/badge/wow-7.3-brightgreen.svg" alt="Up to date with WoW 7.3 Legion" />
-<img src="https://img.shields.io/badge/version-0.2.0-blue.svg" alt="Addon on version 0.2.0" />
+<img src="https://img.shields.io/badge/version-0.3.1-blue.svg" alt="Addon on version 0.2.0" />
 
 > This addon is currently under active development and is in Alpha stage testing. You will likely encounter bugs, 
 > particularly in the UI as it is has not been fully designed or implemented. If you install this addon in its 


### PR DESCRIPTION
We were attempting to do math on the endedAt value even when
the Current Dungeon was being rendered, when the endedAt was
obviously nil. This would result in several nil references and
the frame would error out.